### PR TITLE
feat: log processed blocks

### DIFF
--- a/cmd/notionsync/main.go
+++ b/cmd/notionsync/main.go
@@ -34,7 +34,13 @@ func main() {
 		fmt.Println("Error calling API:", err)
 		return
 	}
+	processedBlocks := make(map[string]string) // Initialize the map
 
 	outputPath := fmt.Sprintf("output/%s.md", pageName)
-	format.ProcessBlocks(results, outputPath, pageName, apiClient, bearerToken)
+	format.ProcessBlocks(uuid, results, outputPath, pageName, apiClient, bearerToken, processedBlocks)
+	// Once processing is complete, print the map to view the processed blocks
+	// This is just for debugging purposes @TODO: Remove this
+	for blockID, filePath := range processedBlocks {
+		fmt.Printf("BlockID: %s, FilePath: %s\n", blockID, filePath)
+	}
 }

--- a/format/process_blocks.go
+++ b/format/process_blocks.go
@@ -7,10 +7,18 @@ import (
 	"github.com/s-kngstn/notionsync/api"
 )
 
-func ProcessBlocks(results *api.ResultsWrapper, outputPath string, pageName string, apiClient *api.NotionApiClient, bearerToken string) {
+func ProcessBlocks(uuid string, results *api.ResultsWrapper, outputPath string, pageName string, apiClient *api.NotionApiClient, bearerToken string, processedBlocks map[string]string) {
 	// We need to handle if we have a child page block has children and if so, we need to call the API again
 	// The ID of the child page is the UUID of the block
 	for _, block := range results.Results {
+		// Assume every block has a unique ID that can be used as a key in the map
+		blockID := block.ID
+
+		if _, processed := processedBlocks[blockID]; processed {
+			// If the block has already been processed, skip it or handle as needed
+			continue
+		}
+
 		if block.Type == "child_page" && block.HasChildren {
 			// Call the API with the ID of the block
 			childResults, err := apiClient.GetNotionBlocks(block.ID, bearerToken)
@@ -21,6 +29,10 @@ func ProcessBlocks(results *api.ResultsWrapper, outputPath string, pageName stri
 			// The output path will be the same as the parent page, but with the title of the child page name
 			childPageName := strcase.ToKebab(block.ChildPage.Title)
 			childOutputPath := fmt.Sprintf("output/%s.md", childPageName)
+
+			// Before processing child blocks, mark this block as processed to avoid infinite recursion
+			processedBlocks[blockID] = childOutputPath
+
 			// Write the child blocks to a Markdown file with the title of the child pageName
 			if err := WriteBlocksToMarkdown(childResults, childOutputPath, childPageName); err != nil {
 				fmt.Println("Error writing blocks to Markdown:", err)
@@ -28,6 +40,8 @@ func ProcessBlocks(results *api.ResultsWrapper, outputPath string, pageName stri
 		}
 	}
 
+	// Mark the parent block as processed using the original UUID and the output path
+	processedBlocks[uuid] = outputPath
 	// Now process and write the results to a Markdown file
 	if err := WriteBlocksToMarkdown(results, outputPath, pageName); err != nil {
 		fmt.Println("Error writing blocks to Markdown:", err)


### PR DESCRIPTION
This is to prevent infinite loops when processing page links